### PR TITLE
AdviceAPI Enhancement with JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,24 @@ Feel free to go beyond these suggestions if you have ideas that improve the appl
 - Please make sure to implement your enhancements.
 - Update this README.md to explain your changes and decisions.
 - Create a branch and make a pull request.
+
+
+# Advice API (Spring Boot)
+
+This project implements an Advice API with JWT-based authentication, role-based authorization (ADMIN, USER), Advice CRUD, ratings, pagination, H2 in-memory DB, and OpenAPI docs.
+
+## How to run
+1. Ensure Java 17 and Maven are installed.
+2. `mvn spring-boot:run`
+3. Open H2 console: http://localhost:8080/h2-console (JDBC URL: `jdbc:h2:mem:advice-db`)
+4. Open Swagger UI: http://localhost:8080/swagger-ui/index.html
+
+## Initial accounts
+- admin / adminpass (ROLE_ADMIN + ROLE_USER)
+- user / userpass (ROLE_USER)
+
+## Notes
+- JWT secret is stored in `application.yml` for demo only. Replace for production.
+- Roles stored as enum set on the user.
+- Rating endpoint prevents duplicate ratings by updating existing rating by the same user.
+- Suggestions to extend: add DTO mappers, MapStruct, more tests, role management endpoints.

--- a/src/main/java/com/descenedigital/config/DataInitializer.java
+++ b/src/main/java/com/descenedigital/config/DataInitializer.java
@@ -1,0 +1,43 @@
+package com.descenedigital.config;
+
+import com.descenedigital.model.Advice;
+import com.descenedigital.model.Role;
+import com.descenedigital.model.User;
+import com.descenedigital.repo.AdviceRepository;
+import com.descenedigital.repo.UserRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Set;
+
+@Configuration
+public class DataInitializer {
+    @Bean
+    CommandLineRunner init(UserRepository userRepository, AdviceRepository adviceRepository, PasswordEncoder encoder) {
+        return args -> {
+            if (userRepository.findByUsername("admin").isEmpty()) {
+                User admin = new User();
+                admin.setUsername("admin");
+                admin.setPassword(encoder.encode("adminpass"));
+                admin.setRoles(Set.of(Role.ROLE_ADMIN, Role.ROLE_USER));
+                userRepository.save(admin);
+            }
+            if (userRepository.findByUsername("user").isEmpty()) {
+                User user = new User();
+                user.setUsername("user");
+                user.setPassword(encoder.encode("userpass"));
+                user.setRoles(Set.of(Role.ROLE_USER));
+                userRepository.save(user);
+            }
+            if (adviceRepository.count() == 0) {
+                Advice a = new Advice();
+                a.setTitle("Always test your code");
+                a.setContent("Write tests early and often. They save time and reduce bugs.");
+                a.setAuthor("system");
+                adviceRepository.save(a);
+            }
+        };
+    }
+}

--- a/src/main/java/com/descenedigital/config/SecurityConfig.java
+++ b/src/main/java/com/descenedigital/config/SecurityConfig.java
@@ -1,8 +1,47 @@
 package com.descenedigital.config;
 
+
+import com.descenedigital.repo.UserRepository;
+import com.descenedigital.security.JwtFilter;
+import com.descenedigital.security.JwtUtil;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
 
+    public SecurityConfig(JwtUtil jwtUtil, UserRepository userRepository) {
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() { return new BCryptPasswordEncoder(); }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        var jwtFilter = new JwtFilter(jwtUtil);
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/h2-console/**", "/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .httpBasic(httpBasic -> {});
+        return http.build();
+    }
 }

--- a/src/main/java/com/descenedigital/controller/AdviceController.java
+++ b/src/main/java/com/descenedigital/controller/AdviceController.java
@@ -1,10 +1,100 @@
 package com.descenedigital.controller;
 
+import com.descenedigital.dto.AdviceDTO;
+import com.descenedigital.dto.CreateAdviceRequest;
+import com.descenedigital.dto.RateRequest;
+import com.descenedigital.model.Advice;
+import com.descenedigital.model.Rating;
+import com.descenedigital.repo.UserRepository;
+import com.descenedigital.service.AdviceService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/advice")
 public class AdviceController {
 
+
+    private final AdviceService adviceService;
+    private final UserRepository userRepository;
+
+    public AdviceController(AdviceService adviceService, UserRepository userRepository) {
+        this.adviceService = adviceService;
+        this.userRepository = userRepository;
+    }
+
+    private AdviceDTO toDto(Advice a) {
+        AdviceDTO d = new AdviceDTO();
+        d.id = a.getId(); d.title = a.getTitle(); d.content = a.getContent(); d.author = a.getAuthor(); d.createdAt = a.getCreatedAt(); d.updatedAt = a.getUpdatedAt();
+        var avg = a.getRatings().stream().mapToInt(Rating::getValue).average();
+        d.averageRating = avg.isPresent() ? avg.getAsDouble() : null;
+        return d;
+    }
+
+    @PostMapping
+    public ResponseEntity<?> create(@Valid @RequestBody CreateAdviceRequest req, Authentication auth) {
+        // Only ADMIN may create — check authority
+        if (auth == null || auth.getAuthorities().stream().noneMatch(ga -> ga.getAuthority().equals("ROLE_ADMIN"))) {
+            return ResponseEntity.status(403).build();
+        }
+        var created = adviceService.create(req, auth.getName());
+        return ResponseEntity.ok(toDto(created));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> list(@RequestParam(required = false) String q, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+        Pageable p = PageRequest.of(page, size);
+        Page<Advice> res = adviceService.search(q, p);
+        Page<AdviceDTO> dto = new PageImpl<>(res.stream().map(this::toDto).collect(Collectors.toList()), p, res.getTotalElements());
+        return ResponseEntity.ok(dto);
+    }
+
+    @GetMapping("/top-rated")
+    public ResponseEntity<?> topRated(@RequestParam(defaultValue = "5") int limit) {
+        var page = adviceService.topRated(PageRequest.of(0, limit));
+        var dto = page.stream().map(this::toDto).collect(Collectors.toList());
+        return ResponseEntity.ok(dto);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> get(@PathVariable Long id) {
+        Advice a = adviceService.get(id);
+        return ResponseEntity.ok(toDto(a));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> update(@PathVariable Long id, @Valid @RequestBody CreateAdviceRequest req, Authentication auth) {
+        if (auth == null || auth.getAuthorities().stream().noneMatch(ga -> ga.getAuthority().equals("ROLE_ADMIN"))) {
+            return ResponseEntity.status(403).build();
+        }
+        var updated = adviceService.update(id, req);
+        return ResponseEntity.ok(toDto(updated));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id, Authentication auth) {
+        if (auth == null || auth.getAuthorities().stream().noneMatch(ga -> ga.getAuthority().equals("ROLE_ADMIN"))) {
+            return ResponseEntity.status(403).build();
+        }
+        adviceService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/rate")
+    public ResponseEntity<?> rate(@PathVariable Long id, @Valid @RequestBody RateRequest req, Authentication auth) {
+        if (auth == null) return ResponseEntity.status(401).build();
+        var user = userRepository.findByUsername(auth.getName()).orElseThrow();
+        Rating r = adviceService.rate(id, user, req.value);
+        return ResponseEntity.ok(Map.of("ratingId", r.getId(), "value", r.getValue()));
+    }
 
 }

--- a/src/main/java/com/descenedigital/controller/AuthController.java
+++ b/src/main/java/com/descenedigital/controller/AuthController.java
@@ -1,0 +1,46 @@
+package com.descenedigital.controller;
+
+import com.descenedigital.model.User;
+import com.descenedigital.security.JwtUtil;
+import com.descenedigital.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+    private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    public AuthController(UserService userService, PasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
+        this.userService = userService;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    record RegisterRequest(String username, String password) {}
+    record LoginRequest(String username, String password) {}
+
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody @Valid RegisterRequest req) {
+        var user = userService.register(req.username(), req.password());
+        return ResponseEntity.ok(Map.of("id", user.getId(), "username", user.getUsername()));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest req) {
+        User u = userService.findByUsername(req.username());
+        if (u == null) return ResponseEntity.status(401).body(Map.of("error", "Invalid credentials"));
+        if (!passwordEncoder.matches(req.password(), u.getPassword())) return ResponseEntity.status(401).body(Map.of("error", "Invalid credentials"));
+        var roles = u.getRoles().stream().map(Enum::name).map(s -> s).toList();
+        String token = jwtUtil.generateToken(u.getUsername(), u.getRoles().stream().map(Enum::name).collect(java.util.stream.Collectors.toSet()));
+        return ResponseEntity.ok(Map.of("token", token));
+    }
+}
+

--- a/src/main/java/com/descenedigital/dto/AdviceDTO.java
+++ b/src/main/java/com/descenedigital/dto/AdviceDTO.java
@@ -1,0 +1,13 @@
+package com.descenedigital.dto;
+
+import java.time.Instant;
+
+public class AdviceDTO {
+    public Long id;
+    public String title;
+    public String content;
+    public String author;
+    public Instant createdAt;
+    public Instant updatedAt;
+    public Double averageRating;
+}

--- a/src/main/java/com/descenedigital/dto/CreateAdviceRequest.java
+++ b/src/main/java/com/descenedigital/dto/CreateAdviceRequest.java
@@ -1,0 +1,10 @@
+package com.descenedigital.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class CreateAdviceRequest {
+    @NotBlank
+    public String title;
+    @NotBlank
+    public String content;
+}

--- a/src/main/java/com/descenedigital/dto/RateRequest.java
+++ b/src/main/java/com/descenedigital/dto/RateRequest.java
@@ -1,0 +1,9 @@
+package com.descenedigital.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public class RateRequest {
+    @Min(1) @Max(5)
+    public int value;
+}

--- a/src/main/java/com/descenedigital/model/Advice.java
+++ b/src/main/java/com/descenedigital/model/Advice.java
@@ -2,15 +2,25 @@ package com.descenedigital.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
 
 @Entity
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class Advice {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private String title;
+    @Column(length = 4000)
+    private String content;
+    private String author;
+    private Instant createdAt = Instant.now();
+    private Instant updatedAt = Instant.now();
 
-    private String message;
+    @OneToMany(mappedBy = "advice", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Rating> ratings = new ArrayList<>();
 }

--- a/src/main/java/com/descenedigital/model/Rating.java
+++ b/src/main/java/com/descenedigital/model/Rating.java
@@ -1,0 +1,19 @@
+package com.descenedigital.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Data
+public class Rating {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private int value; // 1..5
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Advice advice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+}

--- a/src/main/java/com/descenedigital/model/Role.java
+++ b/src/main/java/com/descenedigital/model/Role.java
@@ -1,0 +1,5 @@
+package com.descenedigital.model;
+
+public enum Role {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/com/descenedigital/model/User.java
+++ b/src/main/java/com/descenedigital/model/User.java
@@ -1,0 +1,22 @@
+package com.descenedigital.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+@Data
+public class User {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(unique = true, nullable = false)
+    private String username;
+    @Column(nullable = false)
+    private String password;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    private Set<Role> roles;
+}
+

--- a/src/main/java/com/descenedigital/repo/AdviceRepo.java
+++ b/src/main/java/com/descenedigital/repo/AdviceRepo.java
@@ -1,7 +1,0 @@
-package com.descenedigital.repo;
-
-import com.descenedigital.model.Advice;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface AdviceRepo extends JpaRepository<Advice, Long> {
-}

--- a/src/main/java/com/descenedigital/repo/AdviceRepository.java
+++ b/src/main/java/com/descenedigital/repo/AdviceRepository.java
@@ -1,0 +1,14 @@
+package com.descenedigital.repo;
+
+import com.descenedigital.model.Advice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface AdviceRepository extends JpaRepository<Advice, Long> {
+    Page<Advice> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(String t, String c, Pageable p);
+
+    @Query("SELECT a FROM Advice a LEFT JOIN a.ratings r GROUP BY a ORDER BY AVG(r.value) DESC")
+    Page<Advice> findTopRated(Pageable pageable);
+}

--- a/src/main/java/com/descenedigital/repo/RatingRepository.java
+++ b/src/main/java/com/descenedigital/repo/RatingRepository.java
@@ -1,0 +1,11 @@
+package com.descenedigital.repo;
+
+import com.descenedigital.model.Advice;
+import com.descenedigital.model.Rating;
+import com.descenedigital.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface RatingRepository extends JpaRepository<Rating, Long> {
+    Optional<Rating> findByAdviceAndUser(Advice advice, User user);
+}

--- a/src/main/java/com/descenedigital/repo/UserRepository.java
+++ b/src/main/java/com/descenedigital/repo/UserRepository.java
@@ -1,0 +1,9 @@
+package com.descenedigital.repo;
+
+import com.descenedigital.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/descenedigital/security/JwtFilter.java
+++ b/src/main/java/com/descenedigital/security/JwtFilter.java
@@ -1,0 +1,47 @@
+package com.descenedigital.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JwtFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+
+    public JwtFilter(JwtUtil jwtUtil) { this.jwtUtil = jwtUtil; }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                Jws<Claims> claims = jwtUtil.validate(token);
+                String username = claims.getBody().getSubject();
+                String rolesRaw = claims.getBody().get("roles", String.class);
+                List<SimpleGrantedAuthority> authorities = Arrays.stream(rolesRaw.split(","))
+                        .filter(s -> !s.isBlank())
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+                var auth = new UsernamePasswordAuthenticationToken(username, null, authorities);
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } catch (Exception ex) {
+                // invalid token — ignore. Downstream security will block if necessary.
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}
+

--- a/src/main/java/com/descenedigital/security/JwtUtil.java
+++ b/src/main/java/com/descenedigital/security/JwtUtil.java
@@ -1,0 +1,37 @@
+package com.descenedigital.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtUtil {
+    private final Key key;
+    private final long expirationMs;
+
+    public JwtUtil(@Value("${jwt.secret}") String secret, @Value("${jwt.expiration-ms}") long expirationMs) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+        this.expirationMs = expirationMs;
+    }
+
+    public String generateToken(String username, Set<String> roles) {
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
+                .setSubject(username)
+                .claim("roles", roles.stream().collect(Collectors.joining(",")))
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + expirationMs))
+                .signWith(key)
+                .compact();
+    }
+
+    public Jws<Claims> validate(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+    }
+}

--- a/src/main/java/com/descenedigital/service/AdviceService.java
+++ b/src/main/java/com/descenedigital/service/AdviceService.java
@@ -1,8 +1,76 @@
 package com.descenedigital.service;
 
+import com.descenedigital.dto.CreateAdviceRequest;
+import com.descenedigital.model.Advice;
+import com.descenedigital.model.Rating;
+import com.descenedigital.model.User;
+import com.descenedigital.repo.AdviceRepository;
+import com.descenedigital.repo.RatingRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.OptionalDouble;
 
 @Service
 public class AdviceService {
+    private final AdviceRepository adviceRepository;
+    private final RatingRepository ratingRepository;
 
+    public AdviceService(AdviceRepository adviceRepository, RatingRepository ratingRepository) {
+        this.adviceRepository = adviceRepository;
+        this.ratingRepository = ratingRepository;
+    }
+
+    public Advice create(CreateAdviceRequest req, String author) {
+        Advice a = new Advice();
+        a.setTitle(req.title);
+        a.setContent(req.content);
+        a.setAuthor(author);
+        return adviceRepository.save(a);
+    }
+
+    public Page<Advice> search(String q, Pageable pageable) {
+        if (q == null || q.isBlank()) return adviceRepository.findAll(pageable);
+        return adviceRepository.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCase(q, q, pageable);
+    }
+
+    public OptionalDouble averageRating(Advice a) {
+        return a.getRatings().stream().mapToInt(Rating::getValue).average();
+    }
+
+    public Page<Advice> topRated(Pageable pageable) {
+        return adviceRepository.findTopRated(pageable);
+    }
+
+    public Advice get(Long id) { return adviceRepository.findById(id).orElseThrow(() -> new RuntimeException("NotFound")); }
+
+    public Advice update(Long id, CreateAdviceRequest req) {
+        Advice a = get(id);
+        a.setTitle(req.title);
+        a.setContent(req.content);
+        a.setUpdatedAt(java.time.Instant.now());
+        return adviceRepository.save(a);
+    }
+
+    public void delete(Long id) { adviceRepository.deleteById(id); }
+
+    @Transactional
+    public Rating rate(Long adviceId, User user, int value) {
+        Advice a = get(adviceId);
+        var existing = ratingRepository.findByAdviceAndUser(a, user);
+        Rating r;
+        if (existing.isPresent()) {
+            r = existing.get();
+            r.setValue(value);
+        } else {
+            r = new Rating();
+            r.setAdvice(a);
+            r.setUser(user);
+            r.setValue(value);
+        }
+        return ratingRepository.save(r);
+    }
 }

--- a/src/main/java/com/descenedigital/service/UserService.java
+++ b/src/main/java/com/descenedigital/service/UserService.java
@@ -1,0 +1,35 @@
+package com.descenedigital.service;
+
+
+import com.descenedigital.model.Role;
+import com.descenedigital.model.User;
+import com.descenedigital.repo.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public User register(String username, String rawPassword) {
+        if (userRepository.findByUsername(username).isPresent()) throw new RuntimeException("Username taken");
+        User u = new User();
+        u.setUsername(username);
+        u.setPassword(passwordEncoder.encode(rawPassword));
+        u.setRoles(Set.of(Role.ROLE_USER));
+        return userRepository.save(u);
+    }
+
+    public User findByUsername(String username) {
+        return userRepository.findByUsername(username).orElse(null);
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,18 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
     database-platform: org.hibernate.dialect.H2Dialect
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+
+jwt:
+  secret: verySecretKeyChangeThis
+  expiration-ms: 3600000
 
 server:
   port: 8080

--- a/src/test/java/com/descenedigital/AdviceApiApplicationTests.java
+++ b/src/test/java/com/descenedigital/AdviceApiApplicationTests.java
@@ -1,7 +1,7 @@
 package com.descenedigital;
 
 import com.descenedigital.model.Advice;
-import com.descenedigital.repo.AdviceRepo;
+import com.descenedigital.repo.AdviceRepository;
 import com.descenedigital.service.AdviceService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.*;
 
 class AdviceApiApplicationTests {
 		@Mock
-		private AdviceRepo adviceRepository;
+		private AdviceRepository adviceRepository;
 
 		@InjectMocks
 		private AdviceService adviceService;


### PR DESCRIPTION
# Advice API (Spring Boot)

This project implements an Advice API with JWT-based authentication, role-based authorization (ADMIN, USER), Advice CRUD, ratings, pagination, H2 in-memory DB, and OpenAPI docs.

## How to run
1. Ensure Java 17 and Maven are installed.
2. `mvn spring-boot:run`
3. Open H2 console: http://localhost:8080/h2-console (JDBC URL: `jdbc:h2:mem:advice-db`)
4. Open Swagger UI: http://localhost:8080/swagger-ui/index.html

## Initial accounts
- admin / adminpass (ROLE_ADMIN + ROLE_USER)
- user / userpass (ROLE_USER)

## Notes
- JWT secret is stored in `application.yml` for demo only. Replace for production.
- Roles stored as enum set on the user.
- Rating endpoint prevents duplicate ratings by updating existing rating by the same user.
- Suggestions to extend: add DTO mappers, MapStruct, more tests, role management endpoints.