### PR TITLE
initial screen task

### DIFF
--- a/src/main/java/com/descenedigital/Mapper/Mapper.java
+++ b/src/main/java/com/descenedigital/Mapper/Mapper.java
@@ -1,0 +1,14 @@
+package com.descenedigital.Mapper;
+
+import com.descenedigital.dto.AdviceResp;
+import com.descenedigital.entity.Advice;
+
+public class Mapper {
+  public static AdviceResp toResp(Advice a){
+    return new AdviceResp(
+      a.getId(), a.getMessage(),
+      a.getCreatedBy()!=null ? a.getCreatedBy().getUsername() : null,
+      a.getAvgRating(), a.getRatingsCount(), a.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/com/descenedigital/common/Messages.java
+++ b/src/main/java/com/descenedigital/common/Messages.java
@@ -1,0 +1,10 @@
+package com.descenedigital.common;
+
+public final class Messages {
+    private Messages() {}
+    public static final String BAD_CREDENTIALS = "Bad credentials";
+    public static final String ACCESS_DENIED   = "Access denied";
+    public static final String VALIDATION_ERR  = "Validation error";
+    public static final String MISSING_BODY    = "Request body is missing or invalid";
+    public static final String UNEXPECTED_ERR  = "Unexpected error";
+}

--- a/src/main/java/com/descenedigital/config/OpenApiConfig.java
+++ b/src/main/java/com/descenedigital/config/OpenApiConfig.java
@@ -1,0 +1,25 @@
+package com.descenedigital.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.*;
+import io.swagger.v3.oas.models.Components;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.*;
+
+@Configuration
+public class OpenApiConfig {
+
+  @Bean
+  public OpenAPI adviceOpenAPI() {
+    return new OpenAPI()
+            .info(new Info().title("Advice API").version("v2")
+                    .description("JWT-authenticated Advice API"))
+            .components(new Components().addSecuritySchemes(
+                    "bearer-jwt",
+                    new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+            ))
+            .addSecurityItem(new SecurityRequirement().addList("bearer-jwt"));
+  }
+
+}

--- a/src/main/java/com/descenedigital/config/SecurityConfig.java
+++ b/src/main/java/com/descenedigital/config/SecurityConfig.java
@@ -1,8 +1,40 @@
 package com.descenedigital.config;
 
+import com.descenedigital.security.JwtAuthFilter;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-@Configuration
-public class SecurityConfig {
 
-}
+    @Configuration
+    @EnableMethodSecurity(prePostEnabled = true)
+    public  class SecurityConfig {
+      private final JwtAuthFilter jwt;
+      public SecurityConfig(JwtAuthFilter jwt){ this.jwt=jwt; }
+
+        @Bean
+        SecurityFilterChain security(HttpSecurity http, JwtAuthFilter jwtAuthFilter) throws Exception {
+            return http
+                    .csrf(cs -> cs.ignoringRequestMatchers("/h2-console/**","/v3/api-docs/**","/swagger-ui/**"))
+                    .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    .authorizeHttpRequests(a -> a
+                            .requestMatchers("/api/auth/**","/v3/api-docs/**","/swagger-ui/**","/swagger-ui/index.html","/h2/**").permitAll()
+                            .anyRequest().authenticated()
+                    )
+                    .headers(h -> h.frameOptions(f -> f.sameOrigin())) // H2 console
+                    .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                    .build();
+        }
+      @Bean
+      PasswordEncoder passwordEncoder(){ return new BCryptPasswordEncoder(); }
+      @Bean
+      AuthenticationManager authenticationManager(AuthenticationConfiguration c) throws Exception { return c.getAuthenticationManager(); }
+    }

--- a/src/main/java/com/descenedigital/controller/AdviceController.java
+++ b/src/main/java/com/descenedigital/controller/AdviceController.java
@@ -1,10 +1,61 @@
 package com.descenedigital.controller;
-
+import com.descenedigital.dto.AdviceCreateReq;
+import com.descenedigital.dto.AdviceResp;
+import com.descenedigital.dto.AdviceUpdateReq;
+import com.descenedigital.dto.PageResp;
+import com.descenedigital.service.AdviceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Advice")
+@SecurityRequirement(name = "bearer-jwt")
 @RestController
 @RequestMapping("/api/advice")
 public class AdviceController {
+    private final AdviceService svc;
+    public AdviceController(AdviceService s){ this.svc = s; }
 
+    @Operation(summary = "Create advice (ADMIN)")
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public AdviceResp create(@RequestBody @Valid AdviceCreateReq req, Authentication auth){
+        return svc.create(req, auth);
+    }
 
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public AdviceResp update(@PathVariable Long id, @RequestBody @Valid AdviceUpdateReq req){
+        return svc.update(id, req);
+    }
+    @Transactional
+    @Operation(summary = "Delete Advice by Id")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{id}") @PreAuthorize("hasRole('ADMIN')")
+    public void delete(@PathVariable Long id){
+        svc.delete(id); }
+
+    @Operation(summary = "List/Search advice (paged)")
+    @GetMapping
+    public PageResp<AdviceResp> list(
+            @RequestParam(required=false) String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size){
+        Pageable p = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC,"createdAt"));
+        return svc.list(q, p);
+    }
+
+    @Operation(summary = "Top-rated advice (paged)")
+    @GetMapping("/top")
+    public PageResp<AdviceResp> top(@RequestParam(defaultValue="0") int page,
+                                    @RequestParam(defaultValue="10") int size){
+        return svc.top(PageRequest.of(page,size));
+    }
 }

--- a/src/main/java/com/descenedigital/controller/AuthController.java
+++ b/src/main/java/com/descenedigital/controller/AuthController.java
@@ -1,0 +1,39 @@
+package com.descenedigital.controller;
+
+import com.descenedigital.dto.JwtResponse;
+import com.descenedigital.dto.LoginRequest;
+import com.descenedigital.dto.RegisterRequest;
+import com.descenedigital.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/auth")
+@Tag(name = "Auth")
+public class AuthController {
+  private final AuthService svc;
+  public AuthController(AuthService svc){ this.svc = svc; }
+
+  @Operation(summary = "Register a new user")
+  @ApiResponse(responseCode = "200", description = "Registered")
+  @PostMapping("/register")
+  public ResponseEntity<Void> register(@RequestBody @Valid RegisterRequest r){
+    svc.register(r);
+    return ResponseEntity.ok().build();
+  }
+  @Operation(summary = "Login and get JWT")
+  @ApiResponses(@ApiResponse(responseCode = "200",
+          content = @Content(schema = @Schema(implementation = JwtResponse.class))))
+  @PostMapping("/login")
+  public JwtResponse login(@RequestBody @Valid LoginRequest r){
+    return svc.login(r);
+  }
+}

--- a/src/main/java/com/descenedigital/controller/RatingController.java
+++ b/src/main/java/com/descenedigital/controller/RatingController.java
@@ -1,0 +1,21 @@
+package com.descenedigital.controller;
+
+
+import com.descenedigital.dto.RateReq;
+import com.descenedigital.dto.RatingResp;
+import com.descenedigital.service.RatingService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/ratings")
+public class RatingController {
+  private final RatingService svc;
+  public RatingController(RatingService s){ this.svc = s; }
+
+  @PostMapping("/{adviceId}")
+  public RatingResp rate(@PathVariable Long adviceId, @RequestBody @Valid RateReq req, Authentication auth){
+    return svc.rate(adviceId, auth.getName(), req);
+  }
+}

--- a/src/main/java/com/descenedigital/dto/AdviceCreateReq.java
+++ b/src/main/java/com/descenedigital/dto/AdviceCreateReq.java
@@ -1,0 +1,3 @@
+package com.descenedigital.dto;
+import jakarta.validation.constraints.*;
+public record AdviceCreateReq(@NotBlank @Size(max=500) String message) {}

--- a/src/main/java/com/descenedigital/dto/AdviceResp.java
+++ b/src/main/java/com/descenedigital/dto/AdviceResp.java
@@ -1,0 +1,3 @@
+package com.descenedigital.dto;
+import java.time.Instant;
+public record AdviceResp(Long id, String text, String createdBy, double avgRating, int ratingsCount, Instant createdAt) {}

--- a/src/main/java/com/descenedigital/dto/AdviceUpdateReq.java
+++ b/src/main/java/com/descenedigital/dto/AdviceUpdateReq.java
@@ -1,0 +1,3 @@
+package com.descenedigital.dto;
+import jakarta.validation.constraints.*;
+public record AdviceUpdateReq(@NotBlank @Size(max=500) String message) {}

--- a/src/main/java/com/descenedigital/dto/JwtResponse.java
+++ b/src/main/java/com/descenedigital/dto/JwtResponse.java
@@ -1,0 +1,4 @@
+package com.descenedigital.dto;
+public record JwtResponse(String accessToken, String tokenType) {
+  public JwtResponse(String token){ this(token,"Bearer"); }
+}

--- a/src/main/java/com/descenedigital/dto/LoginRequest.java
+++ b/src/main/java/com/descenedigital/dto/LoginRequest.java
@@ -1,0 +1,3 @@
+package com.descenedigital.dto;
+import jakarta.validation.constraints.*;
+public record LoginRequest(@NotBlank String username, @NotBlank String password) {}

--- a/src/main/java/com/descenedigital/dto/PageResp.java
+++ b/src/main/java/com/descenedigital/dto/PageResp.java
@@ -1,0 +1,7 @@
+package com.descenedigital.dto;
+import org.springframework.data.domain.Page;
+import java.util.List;
+
+public record PageResp<T>(List<T> items, int page, int size, long total) {
+  public static <T> PageResp<T> of(Page<T> p){ return new PageResp<>(p.getContent(), p.getNumber(), p.getSize(), p.getTotalElements()); }
+}

--- a/src/main/java/com/descenedigital/dto/RateReq.java
+++ b/src/main/java/com/descenedigital/dto/RateReq.java
@@ -1,0 +1,3 @@
+package com.descenedigital.dto;
+import jakarta.validation.constraints.*;
+public record RateReq(@Min(1) @Max(5) int stars) {}

--- a/src/main/java/com/descenedigital/dto/RatingResp.java
+++ b/src/main/java/com/descenedigital/dto/RatingResp.java
@@ -1,0 +1,2 @@
+package com.descenedigital.dto;
+public record RatingResp(Long adviceId, double avgRating, int ratingsCount) {}

--- a/src/main/java/com/descenedigital/dto/RegisterRequest.java
+++ b/src/main/java/com/descenedigital/dto/RegisterRequest.java
@@ -1,0 +1,9 @@
+package com.descenedigital.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+        @NotBlank @Size(min=3,max=40) String username,
+        @NotBlank @Size(min=6,max=100) String password
+) {}

--- a/src/main/java/com/descenedigital/entity/Advice.java
+++ b/src/main/java/com/descenedigital/entity/Advice.java
@@ -1,0 +1,28 @@
+package com.descenedigital.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Advice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String message;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User createdBy;
+
+    private Instant createdAt = Instant.now();
+    private double avgRating;
+    private int ratingsCount;
+
+}

--- a/src/main/java/com/descenedigital/entity/AdviceRating.java
+++ b/src/main/java/com/descenedigital/entity/AdviceRating.java
@@ -1,0 +1,24 @@
+package com.descenedigital.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"advice_id","user_id"}))
+public class AdviceRating {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Advice advice;
+
+    @ManyToOne(optional = false)
+    private User user;
+
+    @Column(nullable = false)
+    private int stars;
+}

--- a/src/main/java/com/descenedigital/entity/User.java
+++ b/src/main/java/com/descenedigital/entity/User.java
@@ -1,0 +1,31 @@
+package com.descenedigital.entity;
+
+import com.descenedigital.entity.enums.Role;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false) 
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    private Set<Role> roles;
+
+    private boolean enabled = true;
+}

--- a/src/main/java/com/descenedigital/entity/enums/Role.java
+++ b/src/main/java/com/descenedigital/entity/enums/Role.java
@@ -1,0 +1,5 @@
+package com.descenedigital.entity.enums;
+
+public enum Role {
+        ADMIN, USER
+}

--- a/src/main/java/com/descenedigital/exceptions/ApiError.java
+++ b/src/main/java/com/descenedigital/exceptions/ApiError.java
@@ -1,0 +1,10 @@
+package com.descenedigital.exceptions;
+
+import java.time.Instant;
+
+public record ApiError(Instant timestamp, String path, String message) {
+
+    public static ApiError of(String path, String message) {
+        return new ApiError(Instant.now(), path, message);
+    }
+}

--- a/src/main/java/com/descenedigital/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/descenedigital/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.descenedigital.exceptions;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        String errorMessage = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(e -> e.getField() + ": " + e.getDefaultMessage())
+                .orElse("Validation error");
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiError.of(request.getRequestURI(), errorMessage));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiError> handleAccessDenied(AccessDeniedException ex, HttpServletRequest request) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiError.of(request.getRequestURI(), "Access denied"));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ApiError> handleRuntimeException(RuntimeException ex, HttpServletRequest request) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiError.of(request.getRequestURI(), ex.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleGenericException(Exception ex, HttpServletRequest request) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiError.of(request.getRequestURI(), "Unexpected error"));
+    }
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiError> handleMissingBody(HttpMessageNotReadableException ex, HttpServletRequest request) {
+        return ResponseEntity
+                .badRequest()
+                .body(ApiError.of(request.getRequestURI(), "Request body is missing or invalid"));
+    }
+}

--- a/src/main/java/com/descenedigital/repo/AdviceRatingRepo.java
+++ b/src/main/java/com/descenedigital/repo/AdviceRatingRepo.java
@@ -1,0 +1,17 @@
+package com.descenedigital.repo;
+
+import com.descenedigital.entity.AdviceRating;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface AdviceRatingRepo extends JpaRepository<AdviceRating, Long> {
+
+    Optional<AdviceRating> findByAdviceIdAndUserId(Long adviceId, Long userId);
+
+    // avg + count (kept simple)
+    @Query("select coalesce(avg(r.stars), 0), count(r) " +
+            "from AdviceRating r where r.advice.id = :adviceId")
+    Object stats(Long adviceId); // will be an Object[]
+}

--- a/src/main/java/com/descenedigital/repo/AdviceRepo.java
+++ b/src/main/java/com/descenedigital/repo/AdviceRepo.java
@@ -1,7 +1,14 @@
 package com.descenedigital.repo;
 
-import com.descenedigital.model.Advice;
+import com.descenedigital.entity.Advice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AdviceRepo extends JpaRepository<Advice, Long> {
+    Page<Advice> findAllByMessageContainingIgnoreCase(String q, Pageable pageable);
+
+    @Query("SELECT a FROM Advice a ORDER BY a.avgRating DESC, a.ratingsCount DESC, a.createdAt DESC")
+    Page<Advice> topRated(Pageable pageable);
 }

--- a/src/main/java/com/descenedigital/repo/UserRepo.java
+++ b/src/main/java/com/descenedigital/repo/UserRepo.java
@@ -1,0 +1,9 @@
+package com.descenedigital.repo;
+
+import com.descenedigital.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepo extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/com/descenedigital/security/CustomUserDetailsService.java
+++ b/src/main/java/com/descenedigital/security/CustomUserDetailsService.java
@@ -1,0 +1,41 @@
+package com.descenedigital.security;
+
+import com.descenedigital.entity.User;
+import com.descenedigital.repo.UserRepo;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepo userRepo;
+
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        // User ko database se find karo
+         User user= (User) userRepo.findByUsername(username).
+                 orElseThrow(()-> new UsernameNotFoundException("User not found: " + username));
+
+        // Roles ko authorities me convert karo
+        List<SimpleGrantedAuthority> authorities = user.getRoles().stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.name()))
+                .toList();
+
+        // Spring Security ka built-in User object return karo
+        return new org.springframework.security.core.userdetails.User(
+                user.getUsername(),
+                user.getPassword(),
+                user.isEnabled(), // enabled
+                true, // accountNonExpired
+                true, // credentialsNonExpired
+                true, // accountNonLocked
+                authorities
+        );
+    }
+}

--- a/src/main/java/com/descenedigital/security/JwtAuthFilter.java
+++ b/src/main/java/com/descenedigital/security/JwtAuthFilter.java
@@ -1,0 +1,86 @@
+package com.descenedigital.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+  private final JwtUtil jwt;
+
+  public JwtAuthFilter(JwtUtil jwt) {
+    this.jwt = jwt;
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest req,
+                                  HttpServletResponse res,
+                                  FilterChain chain) throws ServletException, IOException {
+
+    String auth = req.getHeader("Authorization");
+
+    // No token → just continue; endpoints will decide (401/403) later.
+    if (auth == null || !auth.startsWith("Bearer ")) {
+      chain.doFilter(req, res);
+      return;
+    }
+
+    String token = auth.substring(7);
+
+    try {
+      String username = jwt.subject(token);
+      if (username == null || username.isBlank()) {
+        write401(res, "Invalid token: subject missing");
+        return;
+      }
+
+      List<String> roles = jwt.roles(token);
+      if (roles == null || roles.isEmpty()) {
+        write401(res, "Invalid token: roles missing");
+        return;
+      }
+
+      var authorities = roles.stream()
+              .map(r -> r.startsWith("ROLE_") ? r : "ROLE_" + r)
+              .map(SimpleGrantedAuthority::new)
+              .toList();
+
+      var authentication = new UsernamePasswordAuthenticationToken(username, null, authorities);
+      authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+
+      chain.doFilter(req, res);
+    } catch (ExpiredJwtException e) {
+      write401(res, "Token expired");
+    } catch (JwtException e) {
+      write401(res, "Invalid token");
+    } catch (Exception e) {
+      write500(res, "Authentication error");
+    }
+  }
+
+  private void write401(HttpServletResponse res, String msg) throws IOException {
+    res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    res.setContentType("text/plain;charset=UTF-8");
+    res.getWriter().write(msg);
+  }
+
+  private void write500(HttpServletResponse res, String msg) throws IOException {
+    res.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    res.setContentType("text/plain;charset=UTF-8");
+    res.getWriter().write(msg);
+  }
+}

--- a/src/main/java/com/descenedigital/security/JwtUtil.java
+++ b/src/main/java/com/descenedigital/security/JwtUtil.java
@@ -1,0 +1,44 @@
+package com.descenedigital.security;
+
+import io.jsonwebtoken.*;
+import org.springframework.stereotype.Component;
+import java.util.*;
+import java.util.stream.*;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+@Component
+
+public class JwtUtil {
+    private final String secret = "P7AqhJq4t8bZxLWmcRjVK8YzyJw7DgkThVgFlpRkCqs=";
+    private final long minutes = 60;
+
+    public String generate(String username, Collection<String> roles) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .setSubject(username)
+                .claim("roles", roles)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plus(minutes, ChronoUnit.MINUTES)))
+                .signWith(SignatureAlgorithm.HS256, secret.getBytes())
+                .compact();
+    }
+
+    public String subject(String token) {
+        return parse(token).getBody().getSubject();
+    }
+
+    public List<String> roles(String token) {
+        Object r = parse(token).getBody().get("roles");
+        if (r instanceof List<?> list) {
+            return list.stream().map(Object::toString).collect(Collectors.toList());
+        }
+        return List.of();
+    }
+
+    private Jws<Claims> parse(String token) {
+        return Jwts.parser()
+                .setSigningKey(secret.getBytes())
+                .parseClaimsJws(token);
+    }
+}

--- a/src/main/java/com/descenedigital/service/AdviceService.java
+++ b/src/main/java/com/descenedigital/service/AdviceService.java
@@ -1,8 +1,51 @@
 package com.descenedigital.service;
 
+
+import com.descenedigital.Mapper.Mapper;
+import com.descenedigital.dto.AdviceCreateReq;
+import com.descenedigital.dto.AdviceResp;
+import com.descenedigital.dto.AdviceUpdateReq;
+import com.descenedigital.dto.PageResp;
+import com.descenedigital.entity.Advice;
+import com.descenedigital.entity.User;
+import com.descenedigital.repo.AdviceRatingRepo;
+import com.descenedigital.repo.AdviceRepo;
+import com.descenedigital.repo.UserRepo;
+import org.springframework.data.domain.*;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AdviceService {
+    private final AdviceRepo repo;
+    private final UserRepo users;
+    private final AdviceRatingRepo ratings;
+    public AdviceService(AdviceRepo r, UserRepo u, AdviceRatingRepo ratings){ repo=r; users=u;
+        this.ratings = ratings;
+    }
 
+    public AdviceResp create(AdviceCreateReq req, Authentication auth){
+        User creator = users.findByUsername(auth.getName()).orElse(null);
+        var a = Advice.builder().message(req.message()).createdBy(creator).build();
+        return Mapper.toResp(repo.save(a));
+    }
+
+    public AdviceResp update(Long id, AdviceUpdateReq req){
+        var a = repo.findById(id).orElseThrow();
+        a.setMessage(req.message());
+        return Mapper.toResp(repo.save(a));
+    }
+
+    public void delete(Long id){
+        ratings.deleteById(id);
+        repo.deleteById(id); }
+
+    public PageResp<AdviceResp> list(String search, Pageable pageable){
+        var p = (search==null || search.isBlank()) ? repo.findAll(pageable) : repo.findAllByMessageContainingIgnoreCase(search, pageable);
+        return PageResp.of(p.map(Mapper::toResp));
+    }
+
+    public PageResp<AdviceResp> top(Pageable pageable){
+        return PageResp.of(repo.topRated(pageable).map(Mapper::toResp));
+    }
 }

--- a/src/main/java/com/descenedigital/service/AuthService.java
+++ b/src/main/java/com/descenedigital/service/AuthService.java
@@ -1,0 +1,61 @@
+package com.descenedigital.service;
+
+import com.descenedigital.common.Messages;
+import com.descenedigital.dto.JwtResponse;
+import com.descenedigital.dto.LoginRequest;
+import com.descenedigital.dto.RegisterRequest;
+import com.descenedigital.entity.User;        // ✅ apni entity import karo
+import com.descenedigital.entity.enums.Role;
+import com.descenedigital.repo.UserRepo;
+import com.descenedigital.security.JwtUtil;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+public class AuthService {
+
+  private final UserRepo users;
+  private final PasswordEncoder encoder;
+  private final JwtUtil jwtUtil;
+
+  public AuthService(UserRepo users, PasswordEncoder encoder, JwtUtil jwtUtil) {
+    this.users = users;
+    this.encoder = encoder;
+    this.jwtUtil = jwtUtil;
+  }
+
+  public void register(RegisterRequest req) {
+    // Check if username already exists
+    if (users.findByUsername(req.username()).isPresent()) {
+      throw new RuntimeException("Username already taken");
+    }
+
+    // Create new user with default role USER
+    User newUser = User.builder()
+            .username(req.username())
+            .password(encoder.encode(req.password()))
+            .roles(Set.of(Role.USER))
+            .enabled(true)
+            .build();
+
+    users.save(newUser);
+  }
+
+  public JwtResponse login(LoginRequest req) {
+    User user = (User) users.findByUsername(req.username())
+            .orElseThrow(() -> new RuntimeException(Messages.BAD_CREDENTIALS));
+
+    if (!encoder.matches(req.password(), user.getPassword())) {
+      throw new RuntimeException(Messages.BAD_CREDENTIALS);
+    }
+
+    String token = jwtUtil.generate(
+            user.getUsername(),
+            user.getRoles().stream().map(Enum::name).toList()
+    );
+
+    return new JwtResponse(token);
+  }
+}

--- a/src/main/java/com/descenedigital/service/RatingService.java
+++ b/src/main/java/com/descenedigital/service/RatingService.java
@@ -1,0 +1,58 @@
+package com.descenedigital.service;
+
+import com.descenedigital.dto.RateReq;
+import com.descenedigital.dto.RatingResp;
+import com.descenedigital.entity.Advice;
+import com.descenedigital.entity.AdviceRating;
+import com.descenedigital.entity.User;
+import com.descenedigital.repo.AdviceRatingRepo;
+import com.descenedigital.repo.AdviceRepo;
+import com.descenedigital.repo.UserRepo;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RatingService {
+
+  private final AdviceRepo adviceRepo;
+  private final AdviceRatingRepo ratingRepo;
+  private final UserRepo userRepo;
+
+  public RatingService(AdviceRepo adviceRepo, AdviceRatingRepo ratingRepo, UserRepo userRepo) {
+    this.adviceRepo = adviceRepo;
+    this.ratingRepo = ratingRepo;
+    this.userRepo = userRepo;
+  }
+
+  @Transactional
+  public RatingResp rate(Long adviceId, String username, RateReq req) {
+    int stars = req.stars();
+    if (stars < 1 || stars > 5) {
+      throw new IllegalArgumentException("Stars must be 1–5");
+    }
+
+    Advice advice = adviceRepo.findById(adviceId)
+            .orElseThrow(() -> new IllegalArgumentException("Advice not found: " + adviceId));
+
+    User user = userRepo.findByUsername(username)
+            .orElseThrow(() -> new IllegalArgumentException("User not found: " + username));
+
+    // upsert (advice,user)
+    AdviceRating rating = ratingRepo.findByAdviceIdAndUserId(adviceId, user.getId())
+            .orElseGet(() -> AdviceRating.builder().advice(advice).user(user).build());
+    rating.setStars(stars);
+    ratingRepo.save(rating);
+
+    // refresh stats (simple Object[] handling)
+    Object result = ratingRepo.stats(adviceId);
+    Object[] row = (Object[]) result;                 // [avg(Double), count(Long)]
+    double avg = row[0] == null ? 0.0 : ((Number) row[0]).doubleValue();
+    int count   = row[1] == null ? 0   : ((Number) row[1]).intValue();
+
+    advice.setAvgRating(avg);
+    advice.setRatingsCount(count);
+    adviceRepo.save(advice);
+
+    return new RatingResp(adviceId, avg, count);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,5 @@
 spring:
+
   datasource:
     url: jdbc:h2:mem:advice-db
     driver-class-name: org.h2.Driver
@@ -12,6 +13,17 @@ spring:
       ddl-auto: update
     show-sql: true
     database-platform: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true   # << important
+
+  sql:
+    init:
+      mode: always
 
 server:
   port: 8080
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,15 @@
+-- Default admin user
+INSERT INTO users(id, username, password, enabled)
+VALUES (
+           1,
+           'admin',
+           '$2a$10$v8i45cdvBm6BfmXezIy0yuSvDRtwIWVObGWPNL1a0Sndb9BEVFuBO', -- bcrypt of "pass123"
+           true
+       );
+
+-- Default admin role
+INSERT INTO user_roles(user_id, roles)
+VALUES (1, 'ADMIN');
+
+-- Ensure next generated ID starts from 2
+ALTER TABLE users ALTER COLUMN id RESTART WITH 2;

--- a/src/test/java/com/descenedigital/AdviceApiApplicationTests.java
+++ b/src/test/java/com/descenedigital/AdviceApiApplicationTests.java
@@ -1,15 +1,9 @@
 package com.descenedigital;
 
-import com.descenedigital.model.Advice;
 import com.descenedigital.repo.AdviceRepo;
 import com.descenedigital.service.AdviceService;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.mockito.*;
-import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 
 class AdviceApiApplicationTests {


### PR DESCRIPTION
Implemented hiring-task enhancements on a basic Advice API:

JWT auth (register/login), BCrypt passwords

RBAC (ADMIN/USER) with method security

Advice CRUD (ADMIN-only)

Ratings (1–5) with upsert per user & denormalized avgRating/ratingsCount

Search + Pagination (search, page, size)

Top-rated endpoint

DTOs + Validation & global error handler

Swagger/OpenAPI 3 with JWT “Authorize”

H2 in-memory DB