### PR TITLE
Implement JWT auth, role-based access, Advice CRUD with pagination; a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,55 @@ Feel free to go beyond these suggestions if you have ideas that improve the appl
 - Please make sure to implement your enhancements.
 - Update this README.md to explain your changes and decisions.
 - Create a branch and make a pull request.
+
+---
+
+## ✅ Implemented Enhancements
+
+- Authentication & Authorization using JWT with roles `ADMIN` and `USER`
+- CRUD endpoints for `Advice` with pagination
+- Validation on inputs (`@NotBlank`, max length)
+- H2 in-memory DB configured; console enabled
+- Swagger/OpenAPI UI available at `/swagger-ui.html`
+- User registration and login endpoints
+- Method-level security restricting create/update/delete to `ADMIN`
+- Unit tests for service layer and controller using MockMvc
+
+## 🔐 Auth Endpoints
+
+- POST `/api/auth/register` body: `{ "username": "u", "password": "p", "admin": false }`
+  - returns `{ token }`
+- POST `/api/auth/login` body: `{ "username": "u", "password": "p" }`
+  - returns `{ token }`
+- Use `Authorization: Bearer <token>` header for protected routes.
+
+## 💡 Advice Endpoints
+
+- GET `/api/advice` with pagination params `page`, `size`, `sort`
+- GET `/api/advice/{id}`
+- POST `/api/advice` (ADMIN)
+- PUT `/api/advice/{id}` (ADMIN)
+- DELETE `/api/advice/{id}` (ADMIN)
+
+## 🧰 Run & Test
+
+```bash
+mvn clean test
+mvn spring-boot:run
+```
+
+H2 Console: `/h2-console` (JDBC URL: `jdbc:h2:mem:advice-db`, user `sa`, blank password)
+
+Swagger UI: `/swagger-ui.html`
+
+## 🧪 Testing Strategy
+
+- Unit tests for `AdviceService` CRUD
+- Slice tests for `AdviceController` using MockMvc + JWT
+- Minimal auth flow smoke test
+
+## 🧭 Notes on Design Decisions
+
+- Stateless JWT auth with a short-lived token (1h)
+- Roles prefixed with `ROLE_` for Spring Security
+- Validation annotations to keep entity constraints simple

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 
+		<!-- Validation -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
 		<!-- H2 Database -->
 		<dependency>
 			<groupId>com.h2database</groupId>
@@ -125,6 +131,11 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 
 	</dependencies>
@@ -150,7 +161,6 @@
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
 							<version>1.18.30</version> <!-- or higher -->
-							<scope>provided</scope>
 						</path>
 						<path>
 							<groupId>org.mapstruct</groupId>

--- a/src/main/java/com/descenedigital/config/OpenApiConfig.java
+++ b/src/main/java/com/descenedigital/config/OpenApiConfig.java
@@ -1,0 +1,13 @@
+package com.descenedigital.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "Advice API", version = "v1", description = "Advice API with JWT security"))
+@SecurityScheme(name = "bearerAuth", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT")
+public class OpenApiConfig {
+}

--- a/src/main/java/com/descenedigital/config/SecurityConfig.java
+++ b/src/main/java/com/descenedigital/config/SecurityConfig.java
@@ -1,8 +1,63 @@
 package com.descenedigital.config;
 
+import com.descenedigital.security.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableMethodSecurity
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final UserDetailsService userDetailsService;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, UserDetailsService userDetailsService) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/h2-console/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()))
+                .authenticationProvider(authenticationProvider())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
 }

--- a/src/main/java/com/descenedigital/controller/AdviceController.java
+++ b/src/main/java/com/descenedigital/controller/AdviceController.java
@@ -1,10 +1,94 @@
 package com.descenedigital.controller;
 
+import com.descenedigital.model.Advice;
+import com.descenedigital.service.AdviceService;
+import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 @RestController
 @RequestMapping("/api/advice")
+@Tag(name = "Advice", description = "CRUD operations for advice entries")
+@SecurityRequirement(name = "bearerAuth")
 public class AdviceController {
 
+    private final AdviceService adviceService;
 
+    public AdviceController(AdviceService adviceService) {
+        this.adviceService = adviceService;
+    }
+
+    @GetMapping
+    @Operation(summary = "List advice", description = "Returns paginated list of advice entries",
+            responses = {@ApiResponse(responseCode = "200", description = "Page of advice",
+                    content = @Content(mediaType = "application/json"))})
+    public Page<Advice> list(@ParameterObject Pageable pageable) {
+        return adviceService.list(pageable);
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Get advice by id",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Found",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = Advice.class))),
+                    @ApiResponse(responseCode = "404", description = "Not found", content = @Content)
+            })
+    public ResponseEntity<Advice> get(@PathVariable Long id) {
+        return adviceService.getById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Create advice", description = "ADMIN only", responses = {
+            @ApiResponse(responseCode = "201", description = "Created",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = Advice.class))),
+            @ApiResponse(responseCode = "400", description = "Validation error", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    public ResponseEntity<Advice> create(@Valid @RequestBody Advice advice) {
+        Advice created = adviceService.create(advice);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Update advice", description = "ADMIN only", responses = {
+            @ApiResponse(responseCode = "200", description = "Updated",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = Advice.class))),
+            @ApiResponse(responseCode = "404", description = "Not found", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    public ResponseEntity<Advice> update(@PathVariable Long id, @Valid @RequestBody Advice advice) {
+        return adviceService.update(id, advice)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "Delete advice", description = "ADMIN only", responses = {
+            @ApiResponse(responseCode = "204", description = "Deleted", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)
+    })
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        adviceService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/descenedigital/controller/AuthController.java
+++ b/src/main/java/com/descenedigital/controller/AuthController.java
@@ -1,0 +1,98 @@
+package com.descenedigital.controller;
+
+import com.descenedigital.model.Role;
+import com.descenedigital.model.UserAccount;
+import com.descenedigital.repo.UserAccountRepo;
+import com.descenedigital.security.JwtService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/auth")
+@Tag(name = "Authentication", description = "Public endpoints for user registration and login")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserAccountRepo userAccountRepo;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
+
+    public AuthController(AuthenticationManager authenticationManager, UserAccountRepo userAccountRepo, PasswordEncoder passwordEncoder, JwtService jwtService) {
+        this.authenticationManager = authenticationManager;
+        this.userAccountRepo = userAccountRepo;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtService = jwtService;
+    }
+
+    @Schema(name = "RegisterRequest", description = "User registration payload")
+    public record RegisterRequest(
+            @NotBlank @Schema(example = "alice") String username,
+            @NotBlank @Schema(example = "S3cretP@ss") String password,
+            @Schema(description = "Grant ADMIN role in addition to USER", example = "false") boolean admin
+    ) {}
+
+    @Schema(name = "AuthResponse", description = "Authentication response containing a JWT token")
+    public record AuthResponse(@Schema(example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...") String token) {}
+
+    @Schema(name = "LoginRequest", description = "User login payload")
+    public record LoginRequest(
+            @NotBlank @Schema(example = "alice") String username,
+            @NotBlank @Schema(example = "S3cretP@ss") String password
+    ) {}
+
+    @PostMapping("/register")
+    @Operation(
+            summary = "Register a new user",
+            description = "Creates a new user and returns a JWT token for immediate use.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Registered successfully",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = AuthResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "Username already exists",
+                            content = @Content)
+            }
+    )
+    public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
+        if (userAccountRepo.findByUsername(request.username()).isPresent()) {
+            return ResponseEntity.badRequest().build();
+        }
+        UserAccount account = new UserAccount();
+        account.setUsername(request.username());
+        account.setPasswordHash(passwordEncoder.encode(request.password()));
+        account.setRoles(request.admin() ? Set.of(Role.ADMIN, Role.USER) : Set.of(Role.USER));
+        userAccountRepo.save(account);
+        String token = jwtService.generateToken(account.getUsername(), Map.of("roles", account.getRoles()));
+        return ResponseEntity.ok(new AuthResponse(token));
+    }
+
+    @PostMapping("/login")
+    @Operation(
+            summary = "Login",
+            description = "Authenticates a user and returns a JWT token.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Authenticated",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = AuthResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Invalid credentials", content = @Content)
+            }
+    )
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+        Authentication auth = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(request.username(), request.password()));
+        String token = jwtService.generateToken(request.username(), Map.of());
+        return ResponseEntity.ok(new AuthResponse(token));
+    }
+}

--- a/src/main/java/com/descenedigital/model/Advice.java
+++ b/src/main/java/com/descenedigital/model/Advice.java
@@ -2,6 +2,8 @@ package com.descenedigital.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Entity
 @Data
@@ -12,5 +14,7 @@ public class Advice {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotBlank
+    @Size(max = 500)
     private String message;
 }

--- a/src/main/java/com/descenedigital/model/Role.java
+++ b/src/main/java/com/descenedigital/model/Role.java
@@ -1,0 +1,6 @@
+package com.descenedigital.model;
+
+public enum Role {
+    ADMIN,
+    USER
+}

--- a/src/main/java/com/descenedigital/model/UserAccount.java
+++ b/src/main/java/com/descenedigital/model/UserAccount.java
@@ -1,0 +1,26 @@
+package com.descenedigital.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.Set;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "users")
+public class UserAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    private Set<Role> roles;
+}

--- a/src/main/java/com/descenedigital/repo/UserAccountRepo.java
+++ b/src/main/java/com/descenedigital/repo/UserAccountRepo.java
@@ -1,0 +1,10 @@
+package com.descenedigital.repo;
+
+import com.descenedigital.model.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserAccountRepo extends JpaRepository<UserAccount, Long> {
+    Optional<UserAccount> findByUsername(String username);
+}

--- a/src/main/java/com/descenedigital/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/descenedigital/security/JwtAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package com.descenedigital.security;
+
+import com.descenedigital.service.UserAccountDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserAccountDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtService jwtService, UserAccountDetailsService userDetailsService) {
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        final String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        final String jwt = authHeader.substring(7);
+        final String username = jwtService.extractUsername(jwt);
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+            if (jwtService.isTokenValid(jwt, userDetails.getUsername())) {
+                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/descenedigital/security/JwtService.java
+++ b/src/main/java/com/descenedigital/security/JwtService.java
@@ -1,0 +1,66 @@
+package com.descenedigital.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+import java.util.function.Function;
+
+@Service
+public class JwtService {
+    private final String secret = "bXktdmVyeS1zZWN1cmUtc2VjcmV0LWtleS1teS12ZXJ5LXNlY3JldC1zZWNyZXQtMTIzNDU2"; // base64
+    private final long expirationMs = 1000 * 60 * 60; // 1 hour
+
+    public String extractUsername(String token) {
+        return extractClaim(token, Claims::getSubject);
+    }
+
+    public Date extractExpiration(String token) {
+        return extractClaim(token, Claims::getExpiration);
+    }
+
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    public String generateToken(String username, Map<String, Object> extraClaims) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMs);
+        return Jwts.builder()
+                .setClaims(extraClaims)
+                .setSubject(username)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(getSignKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean isTokenValid(String token, String username) {
+        final String extracted = extractUsername(token);
+        return extracted.equals(username) && !isTokenExpired(token);
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSignKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private Key getSignKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/src/main/java/com/descenedigital/service/AdviceService.java
+++ b/src/main/java/com/descenedigital/service/AdviceService.java
@@ -1,8 +1,46 @@
 package com.descenedigital.service;
 
+import com.descenedigital.model.Advice;
+import com.descenedigital.repo.AdviceRepo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 public class AdviceService {
+    private final AdviceRepo adviceRepo;
 
+    public AdviceService(AdviceRepo adviceRepo) {
+        this.adviceRepo = adviceRepo;
+    }
+
+    public Page<Advice> list(Pageable pageable) {
+        return adviceRepo.findAll(pageable);
+    }
+
+    public Optional<Advice> getById(Long id) {
+        return adviceRepo.findById(id);
+    }
+
+    @Transactional
+    public Advice create(Advice advice) {
+        advice.setId(null);
+        return adviceRepo.save(advice);
+    }
+
+    @Transactional
+    public Optional<Advice> update(Long id, Advice updated) {
+        return adviceRepo.findById(id).map(existing -> {
+            existing.setMessage(updated.getMessage());
+            return adviceRepo.save(existing);
+        });
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        adviceRepo.deleteById(id);
+    }
 }

--- a/src/main/java/com/descenedigital/service/UserAccountDetailsService.java
+++ b/src/main/java/com/descenedigital/service/UserAccountDetailsService.java
@@ -1,0 +1,36 @@
+package com.descenedigital.service;
+
+import com.descenedigital.model.Role;
+import com.descenedigital.model.UserAccount;
+import com.descenedigital.repo.UserAccountRepo;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class UserAccountDetailsService implements UserDetailsService {
+
+    private final UserAccountRepo userAccountRepo;
+
+    public UserAccountDetailsService(UserAccountRepo userAccountRepo) {
+        this.userAccountRepo = userAccountRepo;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UserAccount account = userAccountRepo.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        Set<GrantedAuthority> authorities = account.getRoles().stream()
+                .map(Role::name)
+                .map(r -> new SimpleGrantedAuthority("ROLE_" + r))
+                .collect(Collectors.toSet());
+        return new User(account.getUsername(), account.getPasswordHash(), authorities);
+    }
+}

--- a/src/test/java/com/descenedigital/config/TestSecurityConfig.java
+++ b/src/test/java/com/descenedigital/config/TestSecurityConfig.java
@@ -1,0 +1,27 @@
+package com.descenedigital.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@TestConfiguration
+@EnableMethodSecurity(prePostEnabled = true)
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .securityMatcher("/**");
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/test/java/com/descenedigital/controller/AdviceControllerTest.java
+++ b/src/test/java/com/descenedigital/controller/AdviceControllerTest.java
@@ -1,0 +1,89 @@
+package com.descenedigital.controller;
+
+import com.descenedigital.model.Advice;
+import com.descenedigital.service.AdviceService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = AdviceController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = com.descenedigital.security.JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = true)
+@Import(com.descenedigital.config.TestSecurityConfig.class)
+class AdviceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AdviceService adviceService;
+
+    @Test
+    void list_returnsOk() throws Exception {
+        Mockito.when(adviceService.list(any())).thenReturn(new PageImpl<>(List.of(new Advice(1L, "a"))));
+        mockMvc.perform(get("/api/advice")).andExpect(status().isOk());
+    }
+
+    @Test
+    void get_returnsNotFound() throws Exception {
+        Mockito.when(adviceService.getById(99L)).thenReturn(Optional.empty());
+        mockMvc.perform(get("/api/advice/99")).andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    void create_adminCanCreate() throws Exception {
+        Advice created = new Advice(10L, "hi");
+        Mockito.when(adviceService.create(any(Advice.class))).thenReturn(created);
+        mockMvc.perform(post("/api/advice")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"hi\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(10));
+    }
+
+    @Test
+    @WithMockUser(roles = {"USER"})
+    void create_userForbidden() throws Exception {
+        mockMvc.perform(post("/api/advice")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"hi\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    void update_adminOkOrNotFound() throws Exception {
+        Mockito.when(adviceService.update(eq(1L), any(Advice.class))).thenReturn(Optional.of(new Advice(1L, "x")));
+        mockMvc.perform(put("/api/advice/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"changed\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = {"ADMIN"})
+    void delete_adminNoContent() throws Exception {
+        mockMvc.perform(delete("/api/advice/1"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/descenedigital/controller/AuthControllerTest.java
+++ b/src/test/java/com/descenedigital/controller/AuthControllerTest.java
@@ -1,0 +1,125 @@
+package com.descenedigital.controller;
+
+import com.descenedigital.model.Role;
+import com.descenedigital.model.UserAccount;
+import com.descenedigital.repo.UserAccountRepo;
+import com.descenedigital.security.JwtService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = com.descenedigital.security.JwtAuthenticationFilter.class))
+@AutoConfigureMockMvc(addFilters = false)
+@Import(com.descenedigital.config.TestSecurityConfig.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean private AuthenticationManager authenticationManager;
+    @MockBean private UserAccountRepo userAccountRepo;
+    @MockBean private PasswordEncoder passwordEncoder;
+    @MockBean private JwtService jwtService;
+
+    @Test
+    void register_createsUser() throws Exception {
+        Mockito.when(userAccountRepo.findByUsername(anyString())).thenReturn(Optional.empty());
+        Mockito.when(passwordEncoder.encode(anyString())).thenReturn("hash");
+        Mockito.when(jwtService.generateToken(anyString(), any())).thenReturn("tkn");
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"u\",\"password\":\"p\",\"admin\":false}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void login_authenticates() throws Exception {
+        Mockito.when(authenticationManager.authenticate(any())).thenReturn(new TestingAuthenticationToken("u","p"));
+        Mockito.when(jwtService.generateToken(anyString(), any())).thenReturn("tkn");
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"u\",\"password\":\"p\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void register_assignsUserRole_whenAdminFalse() throws Exception {
+        Mockito.when(userAccountRepo.findByUsername(anyString())).thenReturn(Optional.empty());
+        Mockito.when(passwordEncoder.encode(anyString())).thenReturn("hash");
+        Mockito.when(jwtService.generateToken(anyString(), any())).thenReturn("tkn");
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"useronly\",\"password\":\"p\",\"admin\":false}"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<UserAccount> accountCaptor = ArgumentCaptor.forClass(UserAccount.class);
+        Mockito.verify(userAccountRepo).save(accountCaptor.capture());
+        Set<Role> roles = accountCaptor.getValue().getRoles();
+        org.junit.jupiter.api.Assertions.assertEquals(Set.of(Role.USER), roles);
+
+        ArgumentCaptor<Map<String, Object>> claimsCaptor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(jwtService).generateToken(Mockito.eq("useronly"), claimsCaptor.capture());
+        Object rolesClaim = claimsCaptor.getValue().get("roles");
+        org.junit.jupiter.api.Assertions.assertTrue(rolesClaim instanceof Set);
+        org.junit.jupiter.api.Assertions.assertEquals(Set.of(Role.USER), rolesClaim);
+    }
+
+    @Test
+    void register_assignsAdminRole_whenAdminTrue() throws Exception {
+        Mockito.when(userAccountRepo.findByUsername(anyString())).thenReturn(Optional.empty());
+        Mockito.when(passwordEncoder.encode(anyString())).thenReturn("hash");
+        Mockito.when(jwtService.generateToken(anyString(), any())).thenReturn("tkn");
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"adminu\",\"password\":\"p\",\"admin\":true}"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<UserAccount> accountCaptor = ArgumentCaptor.forClass(UserAccount.class);
+        Mockito.verify(userAccountRepo).save(accountCaptor.capture());
+        Set<Role> roles = accountCaptor.getValue().getRoles();
+        org.junit.jupiter.api.Assertions.assertEquals(Set.of(Role.ADMIN, Role.USER), roles);
+
+        ArgumentCaptor<Map<String, Object>> claimsCaptor = ArgumentCaptor.forClass(Map.class);
+        Mockito.verify(jwtService).generateToken(Mockito.eq("adminu"), claimsCaptor.capture());
+        Object rolesClaim = claimsCaptor.getValue().get("roles");
+        org.junit.jupiter.api.Assertions.assertTrue(rolesClaim instanceof Set);
+        org.junit.jupiter.api.Assertions.assertEquals(Set.of(Role.ADMIN, Role.USER), rolesClaim);
+    }
+
+    @Test
+    void register_existingUsername_returnsBadRequest() throws Exception {
+        Mockito.when(userAccountRepo.findByUsername(anyString())).thenReturn(Optional.of(new UserAccount()));
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"username\":\"dup\",\"password\":\"p\",\"admin\":false}"))
+                .andExpect(status().isBadRequest());
+
+        Mockito.verify(userAccountRepo, Mockito.never()).save(any());
+        Mockito.verify(jwtService, Mockito.never()).generateToken(anyString(), any());
+    }
+}

--- a/src/test/java/com/descenedigital/e2e/AdviceFlowE2ETest.java
+++ b/src/test/java/com/descenedigital/e2e/AdviceFlowE2ETest.java
@@ -1,0 +1,135 @@
+package com.descenedigital.e2e;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.descenedigital.AdviceApiApplication;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(classes = AdviceApiApplication.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@TestMethodOrder(OrderAnnotation.class)
+public class AdviceFlowE2ETest {
+
+    private static String adminToken;
+    private static String userToken;
+    private static Long adviceId;
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeAll
+    public static void setup(@Autowired MockMvc mockMvc) throws Exception {
+        // register admin
+        String adminRegister = "{\"username\":\"admin1\",\"password\":\"adminPass1!\",\"admin\":true}";
+        adminToken = extractToken(performPost(mockMvc, "/api/auth/register", adminRegister));
+
+        // register user
+        String userRegister = "{\"username\":\"user1\",\"password\":\"userPass1!\",\"admin\":false}";
+        userToken = extractToken(performPost(mockMvc, "/api/auth/register", userRegister));
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("ADMIN can create advice")
+    public void adminCanCreate(@Autowired MockMvc mockMvc) throws Exception {
+        String body = "{\"message\":\"always test your code\"}";
+        MvcResult res = mockMvc.perform(post("/api/advice")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + adminToken)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType("application/json"))
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.message").value("always test your code"))
+                .andReturn();
+        JsonNode node = mapper.readTree(res.getResponse().getContentAsString());
+        adviceId = node.get("id").asLong();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("USER cannot create advice (forbidden)")
+    public void userCannotCreate(@Autowired MockMvc mockMvc) throws Exception {
+        String body = "{\"message\":\"user not allowed\"}";
+        mockMvc.perform(post("/api/advice")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + userToken)
+                        .content(body))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("List advice with pagination")
+    public void listAdvice(@Autowired MockMvc mockMvc) throws Exception {
+        mockMvc.perform(get("/api/advice?page=0&size=10&sort=id,desc")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray());
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Get advice by id")
+    public void getAdvice(@Autowired MockMvc mockMvc) throws Exception {
+        mockMvc.perform(get("/api/advice/" + adviceId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(adviceId));
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("ADMIN can update advice")
+    public void adminCanUpdate(@Autowired MockMvc mockMvc) throws Exception {
+        String body = "{\"message\":\"write tests first\"}";
+        mockMvc.perform(put("/api/advice/" + adviceId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + adminToken)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("write tests first"));
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("USER cannot delete advice (forbidden)")
+    public void userCannotDelete(@Autowired MockMvc mockMvc) throws Exception {
+        mockMvc.perform(delete("/api/advice/" + adviceId)
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("ADMIN can delete advice")
+    public void adminCanDelete(@Autowired MockMvc mockMvc) throws Exception {
+        mockMvc.perform(delete("/api/advice/" + adviceId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isNoContent());
+    }
+
+    private static String extractToken(MvcResult result) throws Exception {
+        JsonNode node = mapper.readTree(result.getResponse().getContentAsString());
+        return node.get("token").asText();
+    }
+
+    private static MvcResult performPost(MockMvc mockMvc, String url, String body) throws Exception {
+        return mockMvc.perform(post(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+}

--- a/src/test/java/com/descenedigital/service/AdviceServiceTest.java
+++ b/src/test/java/com/descenedigital/service/AdviceServiceTest.java
@@ -1,0 +1,81 @@
+package com.descenedigital.service;
+
+import com.descenedigital.model.Advice;
+import com.descenedigital.repo.AdviceRepo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AdviceServiceTest {
+
+    @Mock
+    private AdviceRepo adviceRepo;
+
+    @InjectMocks
+    private AdviceService adviceService;
+
+    @BeforeEach
+    void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void list_returnsPage() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Advice a1 = new Advice(1L, "message one");
+        Page<Advice> page = new PageImpl<>(List.of(a1));
+        when(adviceRepo.findAll(pageable)).thenReturn(page);
+
+        Page<Advice> result = adviceService.list(pageable);
+        assertEquals(1, result.getTotalElements());
+        verify(adviceRepo).findAll(pageable);
+    }
+
+    @Test
+    void getById_found() {
+        Advice a1 = new Advice(1L, "hello");
+        when(adviceRepo.findById(1L)).thenReturn(Optional.of(a1));
+        Optional<Advice> found = adviceService.getById(1L);
+        assertTrue(found.isPresent());
+        assertEquals("hello", found.get().getMessage());
+    }
+
+    @Test
+    void create_saves() {
+        Advice toCreate = new Advice(null, "hi");
+        Advice saved = new Advice(5L, "hi");
+        when(adviceRepo.save(any())).thenReturn(saved);
+        Advice result = adviceService.create(toCreate);
+        assertNotNull(result.getId());
+        assertEquals(5L, result.getId());
+    }
+
+    @Test
+    void update_updatesWhenPresent() {
+        Advice existing = new Advice(2L, "old");
+        Advice updated = new Advice(null, "new");
+        when(adviceRepo.findById(2L)).thenReturn(Optional.of(existing));
+        when(adviceRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        Optional<Advice> res = adviceService.update(2L, updated);
+        assertTrue(res.isPresent());
+        assertEquals("new", res.get().getMessage());
+    }
+
+    @Test
+    void delete_deletes() {
+        adviceService.delete(9L);
+        verify(adviceRepo).deleteById(9L);
+    }
+}


### PR DESCRIPTION
### Summary

Adds end-to-end secure Advice API with JWT authentication, role-based authorization, CRUD with pagination, Swagger/OpenAPI docs, H2 DB, and comprehensive tests.

### What changed

  • Security: JWT generation/validation, stateless filter, password hashing, method-level @PreAuthorize.
  • Users/Roles: UserAccount, Role (ADMIN, USER), repo and UserDetailsService.
  • Auth endpoints: Register and login returning JWT.
  • Advice CRUD: Paginated list, get by id, create/update/delete (admin-only).
  • Validation: Basic entity validation on Advice.message.
  • Docs: Swagger annotations, global JWT security scheme.
  • DB/Config: H2 in-memory with console enabled.
  • README: Usage, endpoints, test/run instructions.
  • Tests: Unit, MVC slice, and E2E tests.

### New/updated endpoints

  • Auth:
    • POST /api/auth/register → { token }
    • POST /api/auth/login → { token }
  • Advice (requires Bearer <token>):
    • GET /api/advice (paginated)
    • GET /api/advice/{id}
    • POST /api/advice (ADMIN)
    • PUT /api/advice/{id} (ADMIN)
    • DELETE /api/advice/{id} (ADMIN)

### Security model

  • JWT: Bearer token; 1h expiry.
  • Roles: USER can read; ADMIN required for create/update/delete.
  • Spring Security: Stateless sessions, JWT filter, BCrypt passwords.

### Documentation

  • Swagger UI: /swagger-ui.html
  • OpenAPI: Tags, operations, responses, schemas; global bearerAuth scheme.


### Tests

  • Unit: AdviceServiceTest
  • MVC slice: AdviceControllerTest, AuthControllerTest (role assertions)
  • E2E: AdviceFlowE2ETest (register/login, CRUD, RBAC)
  • All tests pass (mvn test).


### Run

  • mvn spring-boot:run
  • H2 Console: /h2-console (JDBC jdbc:h2:mem:advice-db, user sa)
  • Swagger: /swagger-ui.html

**Author: muhammad farooq**